### PR TITLE
Replace session secret with env var

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -12,10 +12,15 @@ declare module "express-session" {
 }
 
 export function setupAuth(app: Express) {
+  const sessionSecret = process.env.SESSION_SECRET;
+  if (!sessionSecret) {
+    throw new Error("SESSION_SECRET environment variable is not defined");
+  }
+
   // Configuración de sesión
   app.use(
     session({
-      secret: "your-secret-key", // En producción, usar variable de entorno
+      secret: sessionSecret,
       resave: false,
       saveUninitialized: false,
       cookie: {


### PR DESCRIPTION
## Summary
- use `SESSION_SECRET` env variable for express-session
- error if the variable isn't provided

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68643b9450448324b463a02b3a916582