### PR TITLE
Bind server host to env and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# SoulHealing
+
+This project contains a small Express server that serves both API routes and the built client.
+
+## Running the server
+
+Install dependencies first:
+
+```bash
+npm install
+```
+
+Then start the server with Node (for example using `ts-node` during development):
+
+```bash
+node server/index.ts
+```
+
+The server listens on `process.env.PORT` (default `5000`) and binds to `process.env.HOST` (default `0.0.0.0`). Set these variables if you need a different host or port.
+
+Example:
+
+```bash
+HOST=0.0.0.0 PORT=5000 node server/index.ts
+```
+
+Your Android application should connect to `http://<server-ip-address>:5000` (replace with the IP of the machine running the server).

--- a/server/index.ts
+++ b/server/index.ts
@@ -59,8 +59,9 @@ app.use((req, res, next) => {
   // ALWAYS serve the app on port 5000
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const port = 5000;
-  server.listen(5000, "127.0.0.1", () => {
-    log("Servidor escuchando en http://127.0.0.1:5000");
+  const port = Number(process.env.PORT) || 5000;
+  const host = process.env.HOST || "0.0.0.0";
+  server.listen(port, host, () => {
+    log(`Servidor escuchando en http://${host}:${port}`);
   });
 })();


### PR DESCRIPTION
## Summary
- make server host configurable with `process.env.HOST` and default to `0.0.0.0`
- add PORT environment variable support
- add README documenting how to run the server so the Android app can connect

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643c2e47a4832491b2798a54fb1292