### PR TITLE
Add repository declarations to Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,7 +28,9 @@ android {
 }
 
 repositories {
-    flatDir{
+    google()
+    mavenCentral()
+    flatDir {
         dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
     }
 }


### PR DESCRIPTION
## Summary
- update `repositories` block in `android/app/build.gradle` to include `google()` and `mavenCentral()`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68643f3a8e808324a821581788698849